### PR TITLE
require julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: julia
 os:
   - linux
 julia:
+  - 0.7
   - 1.0
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 1.0
+julia 0.7


### PR DESCRIPTION
Just tested this with Julia 0.7 -- it works perfectly fine, so why not make it require 0.7