### PR TITLE
Fix type restrictions and method overwriting

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ end
     @test sum_kbn(i for i=1:1:10) === sum_kbn(i for i=10:-1:1)
     @test sum_kbn([-0.0]) === -0.0
     @test sum_kbn([-0.0,-0.0]) === -0.0
-
+    @test sum_kbn(Iterators.filter(isodd, 1:10)) == 25
     @test isequal(sum_kbn(1:3), 6)
     @test isequal(sum_kbn((i for i in [1,2,3])), 6)
 end


### PR DESCRIPTION
Fixes #24 as well as this:
```
julia> using KahanSummation
[ Info: Precompiling KahanSummation [8e2b3108-d4c1-50be-a7a2-16352aec75c3]
WARNING: Method definition cumsum_kbn(Union{Tuple{Vararg{Typ, N}}, AbstractArray{Typ, N} where N}) where {N, Typ<:Number} in module KahanSummation at /Users/alex/Projects/julia-packages/KahanSummation.jl/src/KahanSummation.jl:14 overwritten at /Users/alex/Projects/julia-packages/KahanSummation.jl/src/KahanSummation.jl:43.
  ** incremental compilation may be fatally broken for this module **
```