### PR TITLE
Leverage Base reduction functions for sum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,9 @@
 name = "KahanSummation"
 uuid = "8e2b3108-d4c1-50be-a7a2-16352aec75c3"
-version = "0.3.1"
+version = "0.4.0"
 
 [compat]
-julia = "1.0"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/KahanSummation.jl
+++ b/src/KahanSummation.jl
@@ -13,6 +13,12 @@ summation algorithm for additional accuracy.
 """
 function cumsum_kbn end
 
+# Note that the implementation for cumsum_kbn will stay as is,
+# since the use of a temporary variable for accumulation in `accumulate!`
+# is an implementation detail and not guaranteed!
+
+# sum is implemented using reducing functions but cumsum cannot be.
+
 cumsum_kbn(x::AbstractArray; dims=:) = _cumsum_kbn(x, dims)
 cumsum_kbn(x; dims=:) = _cumsum_kbn(collect(x), dims)
 

--- a/src/KahanSummation.jl
+++ b/src/KahanSummation.jl
@@ -65,30 +65,74 @@ function _cumsum_kbn(v::AbstractArray{T}, ::Colon) where {T}
 end
 
 """
-    sum_kbn(A)
+    TwicePrecisionN{T}(number)
+    TwicePrecisionN{T}(hi, nlo)
+
+Represents an extended precision number as `x.hi - x.nlo`.
+We store the lower order component as the negation to avoid problems when `x.hi == -0.0`.
+
+This does not subtype Number or Real, being meant primarily for internal use
+in KahanSummation.jl.
+
+Convert a `TwicePrecisionN{T}` back to a `T` by calling `singleprec(tp)`.
+"""
+struct TwicePrecisionN{T}
+    hi::T
+    nlo::T
+end
+
+singleprec(x::TwicePrecisionN{T}) where {T} = convert(T, x)
+
+# Implement Base methods
+Base.convert(::Type{TwicePrecisionN{T}}, x::Number) where {T} =
+    TwicePrecisionN{T}(convert(T, x), zero(T))
+Base.convert(::Type{T}, x::TwicePrecisionN) where {T} =
+    convert(T, x.hi - x.nlo)
+
+# Two-sum implementation
+@inline function plus_kbn(x::T, y::T) where {T}
+    hi = x + y
+    nlo = abs(x) > abs(y) ? (hi - x ) - y : (hi - y) - x
+    TwicePrecisionN(hi, nlo)
+end
+@inline function plus_kbn(x::T, y::TwicePrecisionN{T}) where {T}
+    hi = x + y.hi
+    if abs(x) > abs(y.hi)
+        nlo = ((hi - x) - y.hi) + y.nlo
+    else
+        nlo = ((hi - y.hi) - x) + y.nlo
+    end
+    TwicePrecisionN(hi, nlo)
+end
+@inline plus_kbn(x::TwicePrecisionN{T}, y::T) where {T} = plus_kbn(y, x)
+
+@inline function plus_kbn(x::TwicePrecisionN{T}, y::TwicePrecisionN{T}) where {T}
+    hi = x.hi + y.hi
+    if abs(x.hi) > abs(y.hi)
+        nlo = (((hi - x.hi) - y.hi) + y.nlo) + x.nlo
+    else
+        nlo = (((hi - y.hi) - x.hi) + x.nlo) + y.nlo
+    end
+    TwicePrecisionN(hi, nlo)
+end
+
+# Implement methods for accumulators, specifically mapreduce
+Base.mapreduce_empty(f, ::typeof(plus_kbn), T) = TwicePrecisionN(zero(T),zero(T))
+Base.mapreduce_empty(::typeof(identity), ::typeof(plus_kbn), T) = TwicePrecisionN(zero(T),zero(T)) # disambiguate
+Base.mapreduce_first(f, ::typeof(plus_kbn), x) = TwicePrecisionN(x, zero(x))
+
+# Finally, the implementation of `sum_kbn` is trivial, dispatching to `mapreduce`.  
+# Most of the work happens in `plus_kbn`.
+
+"""
+    sum_kbn([f,] A)
 
 Return the sum of all elements of `A`, using the Kahan-Babuska-Neumaier compensated
 summation algorithm for additional accuracy.
 """
-function sum_kbn(A)
-    T = Base.@default_eltype(A)
-    c = Base.reduce_empty(+, T)
-    it = iterate(A)
-    it === nothing && return c
-    Ai, i = it
-    s = Ai - c
-    while (it = iterate(A, i)) !== nothing
-        Ai, i = it::Tuple{T, Int}
-        t = s + Ai
-        if abs(s) >= abs(Ai)
-            c -= ((s-t) + Ai)
-        else
-            c -= ((Ai-t) + s)
-        end
-        s = t
-    end
-    s - c
-end
+sum_kbn(f, X; kw..) = singleprec(mapreduce(f, plus_kbn, X; kw...))
+sum_kbn(X; kw...) = sum_kbn(identity, X; kw...)
+
 
 ### Deprecations
 

--- a/src/KahanSummation.jl
+++ b/src/KahanSummation.jl
@@ -130,7 +130,7 @@ Base.mapreduce_first(f, ::typeof(plus_kbn), x) = TwicePrecisionN(x, zero(x))
 Return the sum of all elements of `A`, using the Kahan-Babuska-Neumaier compensated
 summation algorithm for additional accuracy.
 """
-sum_kbn(f, X; kw..) = singleprec(mapreduce(f, plus_kbn, X; kw...))
+sum_kbn(f, X; kw...) = singleprec(mapreduce(f, plus_kbn, X; kw...))
 sum_kbn(X; kw...) = sum_kbn(identity, X; kw...)
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,3 +49,15 @@ end
     @test isequal(sum_kbn(1:3), 6)
     @test isequal(sum_kbn((i for i in [1,2,3])), 6)
 end
+
+@testset "twice-precision addition"
+    # Note: the functions and types used here are internal
+
+    # The intent of this test is to make sure that the two-sum
+    # works on two twiceprecision numbers correctly, nothing else.
+    i1 = convert(KahanSummation.TwicePrecisionN{Float64}, 1e100)
+    i2 = KahanSummation.TwicePrecisionN{Float64}(-1e100, 1)
+    i12 = KahanSummation.plus_kbn(i1, i2)
+    f12 = KahanSummation.singleprec(i12)
+    @test f12 == 1
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,9 @@ end
     @test sum_kbn(Iterators.filter(isodd, 1:10)) == 25
     @test isequal(sum_kbn(1:3), 6)
     @test isequal(sum_kbn((i for i in [1,2,3])), 6)
+    # also test `sum_kbn(f, x)`
+    @test sum_kbn(x -> x + 1, [7 8 9]) == sum_kbn([7 8 9] .+ 1)
+    @test sum_kbn(x -> x + 1, Float64[]) == zero(Float64)
 end
 
 @testset "twice-precision addition"
@@ -60,4 +63,8 @@ end
     i12 = KahanSummation.plus_kbn(i1, i2)
     f12 = KahanSummation.singleprec(i12)
     @test f12 == 1
+
+    i1 = convert(KahanSummation.TwicePrecisionN{Float64}, 5)
+    i2 = convert(KahanSummation.TwicePrecisionN{Float64}, 3)
+    @test KahanSummation.singleprec(KahanSummation.plus_kbn(i1, i2)) == 5.0 + 3.0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,7 @@ end
     @test sum_kbn(x -> x + 1, Float64[]) == zero(Float64)
 end
 
-@testset "twice-precision addition"
+@testset "twice-precision addition" begin
     # Note: the functions and types used here are internal
 
     # The intent of this test is to make sure that the two-sum
@@ -64,7 +64,9 @@ end
     f12 = KahanSummation.singleprec(i12)
     @test f12 == 1
 
+    # test the bottom if statement in sum_kbn too, or try to at least
     i1 = convert(KahanSummation.TwicePrecisionN{Float64}, 5)
     i2 = convert(KahanSummation.TwicePrecisionN{Float64}, 3)
     @test KahanSummation.singleprec(KahanSummation.plus_kbn(i1, i2)) == 5.0 + 3.0
+    @test KahanSummation.singleprec(KahanSummation.plus_kbn(i2, i1)) == 5.0 + 3.0
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,7 +62,7 @@ end
     i2 = KahanSummation.TwicePrecisionN{Float64}(-1e100, 1)
     i12 = KahanSummation.plus_kbn(i1, i2)
     f12 = KahanSummation.singleprec(i12)
-    @test f12 == 1
+    @test f12 == -1
 
     # test the bottom if statement in sum_kbn too, or try to at least
     i1 = convert(KahanSummation.TwicePrecisionN{Float64}, 5)


### PR DESCRIPTION
Re-implementation of #7 with some extra tests.  I could use Kahan summation in some GeometryOps.jl things I am doing, especially the `sum_kbn(f, itr)` form.

```
# this implementation
julia> @be sum_kbn($(rand(1000)))
Benchmark: 3348 samples with 16 evaluations
 min    1.677 μs
 median 1.734 μs
 mean   1.738 μs
 max    7.698 μs

# the implementation on master
julia> @be KahanSummation.sum_kbn($(rand(1000)))
Benchmark: 3336 samples with 16 evaluations
 min    1.682 μs
 median 1.698 μs
 mean   1.740 μs
 max    4.336 μs

# compared to current Base pairwise summation, slower of course
julia> @be sum($(rand(1000)))
Benchmark: 3198 samples with 290 evaluations
 min    98.131 ns
 median 98.707 ns
 mean   100.700 ns
 max    268.390 ns
```
I attached a timer output and it never calls the method for two TwicePrecisions.  (Annotations mine)
```
julia> to
────────────────────────────────────────────────────────────────────
                           Time                    Allocations      
                  ───────────────────────   ────────────────────────
Tot / % measured:      2.13s /   0.8%           3.68MiB /   0.0%    

Section                           ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────
+(::Float64, ::TwicePrecisionN)     1.72M   17.9ms   99.9%  10.4ns     0.00B     - %    0.00B
+(::Float64, ::Float64)             1.72k   17.4μs    0.1%  10.1ns     0.00B     - %    0.00B
───────────────────────────────────────────────────────────────────────────────
```